### PR TITLE
Phase 1: Update low-risk packages (prettier ecosystem + TypeScript)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.8.31",
-		"@trivago/prettier-plugin-sort-imports": "^4.3.0",
+		"@trivago/prettier-plugin-sort-imports": "^4.4.0",
 		"@zaher/prettier-config": "^1.0.4",
-		"prettier": "^3.2.5",
-		"prettier-plugin-toml": "^2.0.1",
-		"typescript": "^5.3.3",
+		"prettier": "^3.4.0",
+		"prettier-plugin-toml": "^2.0.2",
+		"typescript": "^5.7.0",
 		"vitest": "^3.1.4",
 		"wrangler": "^4.16.0"
 	},


### PR DESCRIPTION
Updated packages:
- prettier: ^3.2.5 → ^3.4.0
- prettier-plugin-toml: ^2.0.1 → ^2.0.2
- @trivago/prettier-plugin-sort-imports: ^4.3.0 → ^4.4.0
- typescript: ^5.3.3 → ^5.7.0

Phase 1 focuses on low-risk formatting and tooling updates. Testing should be performed after npm install.